### PR TITLE
fix: invalid src file path

### DIFF
--- a/config
+++ b/config
@@ -1,7 +1,7 @@
 ngx_addon_name=ngx_http_limit_traffic_rate_filter_module
 
 TRAFFIC_MODULE_SRCS="                                                         \
-                $ngx_addon_dir/src/ngx_http_limit_traffic_rate_filter_module.c    \
+                $ngx_addon_dir/ngx_http_limit_traffic_rate_filter_module.c    \
                 "
 
 TRAFFIC_MODULE_DEPS=""


### PR DESCRIPTION
The source file path in the build config file does not match the file in the actual repository. The source code file is located in the repository root directory, not in the subdirectory src.